### PR TITLE
Change press in nav to updates

### DIFF
--- a/src/_includes/components/banner.njk
+++ b/src/_includes/components/banner.njk
@@ -11,7 +11,7 @@
       <li><a href="/narrative-change">Narrative Change</a></li>
       <li><a href="/policy-lab">Policy Lab</a></li>
       <li><a href="/ventures">Ventures</a></li>
-      <li><a href="/press">Press</a></li>
+      <li><a href="/press">Updates</a></li>
       <li><a href="/contact-us">Contact Us</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
From Anthony on the id42 side

"Where it currently says "Press" in the nav, can you change that to say "Updates"? It can stay linked to the same Press page as the footer, and the footer can stay listed as "Press." We just thought "Updates" would be more compelling/clear in the nav for lay users that land on the page."