### PR TITLE
update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,9 +5,9 @@
   "ignorePaths": [".github/**"],
   "packageRules": [{
     "matchUpdateTypes": ["minor", "patch"],
-    "matchCurrentVersion": "!/^0/"
+    "matchCurrentVersion": "!/^0/",
+    "automerge": true,
+    "automergeStrategy": "squash"
   }],
-  "automerge": true,
-  "automergeStrategy": "squash",
   "rebaseStalePrs": true
 }


### PR DESCRIPTION
Moving automerge into the package rules. 

So TIL:
1. You can use basically all config options in the specific package rules section
2. If you specify automerge _outside_ of that, it applies automerge to ALL prs (including major!!!!)